### PR TITLE
sets the viewpunch in OnTakeDamagePost also

### DIFF
--- a/addons/sourcemod/scripting/noviewpunch.sp
+++ b/addons/sourcemod/scripting/noviewpunch.sp
@@ -67,6 +67,14 @@ public void Hook_Spawn(Event event, const char[] name, bool dontBroadcast)
 			SetEntityModel(client, "models/player/ctm_idf_variantc.mdl");
 		}
 	}	
+
+	SDKHook(client, SDKHook_OnTakeDamagePost, Hook_OnTakeDamagePost);
+}
+
+void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype)
+{
+	float punch[3] = {0.75, 0.0, 0.0};
+	SetEntPropVector(victim, Prop_Send, "m_viewPunchAngle", punch);
 }
 
 public void OnClientPutInServer(int client)


### PR DESCRIPTION
shavit-misc.sp uses an OnTakeDamage hook to set aimpunch to NULL_VECTOR which conflicts with this slightly. wasn't sure if there was a better hook to put this in but OnTakeDamagePost works well